### PR TITLE
fix indexing of lines read from sources.conf for being able to …

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.config.vdr"
        name="VDR Configuration"
-       version="1.0.8"
+       version="1.0.9"
        provider-name="OpenELEC">
    <requires>
      <import addon="os.openelec.tv" version="5.0"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+2016-04-22 v1.0.9
+  (chg) fix reading lines from sources.conf in the right order
+
 2015-05-29 v1.0.8
   (add) support for usals in custom config
   (chg) fix port addressing in diseqc 1.0

--- a/diseqc.py
+++ b/diseqc.py
@@ -429,7 +429,7 @@ class cWinDiSEqC(xbmcgui.WindowXMLDialog):
                     lStrLong = lStrLine[lIntSplitPos:].strip()
                     if len(lStrShort) >= 2 and len(lStrLong)>= 2:
                         self.lDicSatellites[lStrShort] = {'name':lStrLong,'index':lIntSatCount}
-                        ++lIntSatCount
+                        lIntSatCount = lIntSatCount + 1
         
     def fncAddListItem(self, lStrLabel, lStrEntry, lStrValue, lStrAction, lStrTyp, lStrInfoText="", lDicProperties={}):
         lLstItem = xbmcgui.ListItem(label=lStrLabel)


### PR DESCRIPTION
… restore the order when displaying the satellite list in the diseqc configuration dialog. There, the order is that of the dictionary (an arbitrary one), because sorted(...) to a list before feeding the GUI dialog does not work when all indices are actually 1. This modification fixes this. The satllite list displayed in the scan menu was correctly sorted, but that one comes from wirbelscan via restfulapi, I guess...
